### PR TITLE
Ghost mode

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -19,6 +19,10 @@
     background: rgba(255, 255, 255, 0.25);
 }
 
+.lyrics:backdrop.translucid-backdrop .titlebar * {
+    opacity: 0;
+}
+
 .lyrics.dark:backdrop.translucid-backdrop,
 .lyrics.dark:backdrop.translucid-backdrop .titlebar {
     color: #fff;

--- a/data/Application.css
+++ b/data/Application.css
@@ -19,10 +19,6 @@
     background: rgba(255, 255, 255, 0.25);
 }
 
-.lyrics:backdrop.translucid-backdrop .titlebar * {
-    opacity: 0;
-}
-
 .lyrics.dark:backdrop.translucid-backdrop,
 .lyrics.dark:backdrop.translucid-backdrop .titlebar {
     color: #fff;

--- a/data/com.github.naaando.lyrics.gschema.xml
+++ b/data/com.github.naaando.lyrics.gschema.xml
@@ -48,5 +48,13 @@
       <summary>Hide headerbar widgets on backdrop</summary>
       <description>Whether the widgets on headerbar should be hidden on backdrop</description>
     </key>
+    <key name="ghost-mode" type="b">
+      <default>true</default>
+      <summary>Click through the window</summary>
+      <description>
+        Make possible to click through the window when it goes to backdrop and
+        translucid window is activated
+      </description>
+    </key>
   </schema>
 </schemalist>

--- a/data/com.github.naaando.lyrics.gschema.xml
+++ b/data/com.github.naaando.lyrics.gschema.xml
@@ -43,5 +43,10 @@
       <summary>Default font for lyrics</summary>
       <description>Use [Font name][Style][Size] Open Sans Light 12</description>
     </key>
+    <key name="hide-headerbar-widgets-on-backdrop" type="b">
+      <default>true</default>
+      <summary>Hide headerbar widgets on backdrop</summary>
+      <description>Whether the widgets on headerbar should be hidden on backdrop</description>
+    </key>
   </schema>
 </schemalist>

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ executable(
     'src/View/MainWindow.vala',
     'src/View/SearchLyricDialog.vala',
     'src/View/SettingsPopover.vala',
+    'src/View/Helper/ClickThroughHelper.vala',
     'src/View/Helper/SaveWindowStateMixin.vala',
     'src/View/Widgets/Displays/IDisplay.vala',
     'src/View/Widgets/Displays/SimpleDisplay.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -35,7 +35,9 @@ public class Lyrics.Application : Gtk.Application {
         players.on_active_player_changed.connect (() => display_view.on_player_change (players.active_player));
 
         var main_window = new MainWindow (this, players, main_stack);
-        main_window.set_titlebar (new Lyrics.HeaderBar (players, lyrics_service));
+        var header_bar = new Lyrics.HeaderBar (players, lyrics_service);
+        main_window.bind_property ("is-active", header_bar, "parent-window-is-active", BindingFlags.DEFAULT);
+        main_window.set_titlebar (header_bar);
         main_window.show_all ();
 
         var quit_action = new SimpleAction ("quit", null);

--- a/src/View/HeaderBar.vala
+++ b/src/View/HeaderBar.vala
@@ -1,4 +1,6 @@
 public class Lyrics.HeaderBar : Gtk.HeaderBar {
+    public bool parent_window_is_active { get; set; }
+
     Gtk.Settings settings = Gtk.Settings.get_default ();
     Gtk.Button play_n_pause_btn;
     Players players;
@@ -35,6 +37,24 @@ public class Lyrics.HeaderBar : Gtk.HeaderBar {
         pack_end (settings);
         pack_end (create_mode_switch ());
         pack_end (create_lyrics_search ());
+
+        Application.settings.changed["hide-headerbar-widgets-on-backdrop"].connect (configure_widgets_on_backdrop);
+        notify["parent-window-is-active"].connect (() => configure_widgets_on_backdrop ());
+    }
+
+    void configure_widgets_on_backdrop () {
+        var should_hide_widgets = Application.settings.get_boolean ("hide-headerbar-widgets-on-backdrop");
+
+        //  Wrap within timeout to avoid activating a button
+        Timeout.add (50, () => {
+            if (parent_window_is_active || !should_hide_widgets) {
+                show_all ();
+            } else {
+                @foreach (widget => widget.hide ());
+            }
+
+            return false;
+        });
     }
 
     void update_play_n_pause_icon () {

--- a/src/View/Helper/ClickThroughHelper.vala
+++ b/src/View/Helper/ClickThroughHelper.vala
@@ -1,0 +1,47 @@
+public class ClickThroughHelper : Object {
+    Gtk.Window window;
+    ulong signal_id;
+    bool inactive_only;
+
+    public ClickThroughHelper (Gtk.Window window) {
+        this.window = window;
+    }
+
+    public void enable (bool inactive_only = true) {
+        this.inactive_only = inactive_only;
+
+        mask_input ();
+        signal_id = window.event.connect (listen_to_window_events);
+    }
+
+    public void disable () {
+        window.disconnect (signal_id);
+        window.input_shape_combine_region (null);
+    }
+
+    void mask_input () {
+        window.input_shape_combine_region (!inactive_only || !window.is_active ? create_mask () : null);
+    }
+
+    bool listen_to_window_events (Gdk.Event event) {
+        if (event.type == Gdk.EventType.WINDOW_STATE) {
+            mask_input ();
+        }
+
+        //  Propagate event
+        return false;
+    }
+
+    /**
+     * Create a region with the window size
+     *
+     * @return cairo region with window size
+     */
+    Cairo.Region create_mask () {
+        int width, height;
+        window.get_size (out width, out height);
+        var event_mask = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
+
+        return Gdk.cairo_region_create_from_surface (event_mask);
+    }
+}

--- a/src/View/MainWindow.vala
+++ b/src/View/MainWindow.vala
@@ -34,7 +34,7 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
         add (main_stack);
         setup ();
 
-        Timeout.add_seconds (1 , () => {
+            GLib.Timeout.add_seconds (1, () => {
             if (is_active) {
                 input_shape_combine_region (null);
             } else {

--- a/src/View/MainWindow.vala
+++ b/src/View/MainWindow.vala
@@ -4,7 +4,7 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
     Players players;
     bool keep_above_when_playing;
     Gtk.CssProvider custom_font_provider;
-    Cairo.Surface event_mask;
+    ClickThroughHelper ghost_mode;
 
     public MainWindow (Gtk.Application application, Players _players, Gtk.Stack stack) {
         Object (
@@ -20,6 +20,9 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
         //  SaveWindowStateMixin's restore window functionality
         enable_restore_state (Application.settings);
 
+        //  Click through functionality
+        ghost_mode = new ClickThroughHelper (this);
+
         //  Add css classes to main window
         get_style_context ().add_class ("rounded");
         get_style_context ().add_class ("lyrics");
@@ -34,19 +37,6 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
 
         add (main_stack);
         setup ();
-
-        GLib.Timeout.add_seconds (1, () => {
-            if (is_active) {
-                input_shape_combine_region (null);
-            } else {
-                int width;
-                int height;
-                get_size (out width, out height);
-                event_mask = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
-                input_shape_combine_region(Gdk.cairo_region_create_from_surface (event_mask));
-            }
-            return true;
-        });
     }
 
     void setup () {

--- a/src/View/MainWindow.vala
+++ b/src/View/MainWindow.vala
@@ -87,8 +87,10 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
     void configure_window_opacity_on_focus_loss () {
         if (Application.settings.get_boolean ("window-out-of-focus-translucid")) {
             get_style_context ().add_class ("translucid-backdrop");
+            ghost_mode.enable ();
         } else {
             get_style_context ().remove_class ("translucid-backdrop");
+            ghost_mode.disable ();
         }
     }
 

--- a/src/View/MainWindow.vala
+++ b/src/View/MainWindow.vala
@@ -33,6 +33,7 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
         Application.settings.changed["window-keep-above"].connect (configure_window_keep_above_settings);
         Application.settings.changed["window-out-of-focus-translucid"].connect (configure_window_opacity_on_focus_loss);
         Application.settings.changed["font"].connect (configure_font);
+        Application.settings.changed["ghost-mode"].connect (configure_ghost_mode);
         main_stack.notify["visible-child-name"].connect (on_stack_visible_child_changed);
 
         add (main_stack);
@@ -44,6 +45,7 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
         configure_css_provider ();
         configure_window_keep_above_settings ();
         configure_window_opacity_on_focus_loss ();
+        configure_ghost_mode ();
         configure_font ();
         stick ();
     }
@@ -87,9 +89,19 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
     void configure_window_opacity_on_focus_loss () {
         if (Application.settings.get_boolean ("window-out-of-focus-translucid")) {
             get_style_context ().add_class ("translucid-backdrop");
-            ghost_mode.enable ();
         } else {
             get_style_context ().remove_class ("translucid-backdrop");
+        }
+    }
+
+
+    void configure_ghost_mode () {
+        var is_translucid = Application.settings.get_boolean ("window-out-of-focus-translucid");
+        var ghost_mode_activated = Application.settings.get_boolean ("ghost-mode");
+
+        if (is_translucid && ghost_mode_activated) {
+            ghost_mode.enable ();
+        } else {
             ghost_mode.disable ();
         }
     }

--- a/src/View/MainWindow.vala
+++ b/src/View/MainWindow.vala
@@ -4,6 +4,7 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
     Players players;
     bool keep_above_when_playing;
     Gtk.CssProvider custom_font_provider;
+    Cairo.Surface event_mask;
 
     public MainWindow (Gtk.Application application, Players _players, Gtk.Stack stack) {
         Object (
@@ -41,7 +42,7 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
                 int width;
                 int height;
                 get_size (out width, out height);
-                event_mask = new ImageSurface (Format.ARGB32, width, height);
+                event_mask = new Cairo.ImageSurface (Cairo.Format.ARGB32, width, height);
                 input_shape_combine_region(Gdk.cairo_region_create_from_surface (event_mask));
             }
             return true;

--- a/src/View/MainWindow.vala
+++ b/src/View/MainWindow.vala
@@ -33,6 +33,19 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
 
         add (main_stack);
         setup ();
+
+        Timeout.add_seconds (1 , () => {
+            if (is_active) {
+                input_shape_combine_region (null);
+            } else {
+                int width;
+                int height;
+                get_size (out width, out height);
+                event_mask = new ImageSurface (Format.ARGB32, width, height);
+                input_shape_combine_region(Gdk.cairo_region_create_from_surface (event_mask));
+            }
+            return true;
+        });
     }
 
     void setup () {

--- a/src/View/MainWindow.vala
+++ b/src/View/MainWindow.vala
@@ -34,7 +34,7 @@ public class Lyrics.MainWindow : Gtk.ApplicationWindow, SaveWindowStateMixin {
         add (main_stack);
         setup ();
 
-            GLib.Timeout.add_seconds (1, () => {
+        GLib.Timeout.add_seconds (1, () => {
             if (is_active) {
                 input_shape_combine_region (null);
             } else {


### PR DESCRIPTION
- Let clicks pass through the window when it is translucid
- Hide headerbar widgets when the app goes backdrop
- Makes headerbar clickable on ghost mode to drag and to grab focus