### PR TITLE
Drop unused libsoup and xmlbird dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,6 @@ deps = [
     dependency ('glib-2.0'),
     dependency ('gtk+-3.0'),
     dependency ('gee-0.8'),
-    dependency ('libsoup-2.4'),
-    dependency ('xmlbird'),
 ]
 
 executable(


### PR DESCRIPTION
These are not required since 0.9.0, when the previous lyrics provider was dropped in favor of syncedlyrics.